### PR TITLE
switch to ubuntu 16.04

### DIFF
--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:yakkety
-# this is ubuntu 16.10
+FROM ubuntu:xenial
+# this is ubuntu 16.04 LTS
 
 MAINTAINER luca.heltai@gmail.com
 


### PR DESCRIPTION
16.04 is the current LTS release. It makes a lot more sense to have a
stable and supported LTS release. The support for 16.10 will run out in
July 2017, so it doesn't make sense to base our images on it. Instead of
switching to 17.04 and then again soon, we can stay on 16.04 for a
while.