### PR TITLE
switch to MPICH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REPO=dealii
 
-RELEASES=v8.5.0
-DEPS=gcc-mpi-fulldepsmanual gcc-mpi-fulldepscandi clang-serial-bare
+RELEASES=v8.5.1
+DEPS=gcc-mpi-fulldepscandi clang-mpi-base clang-serial-bare
 BUILDS=debugrelease
 
 # General name is of the type $REPO/dealii:version-compiler-serialormpi-depstype-buildtype
@@ -26,11 +26,11 @@ build_c	 = $(subst release,Release,$(subst debug,Debug,$(call build,$1)))
 .SECONDARY:
 
 # Base systems
-locks/base-gcc-mpi: locks/base-gcc-serial
+locks/base-gcc-mpi: locks/base-gcc-serial base/gcc-mpi/Dockerfile
 	$(DOCKER_BUILD) -t $(REPO)/base:gcc-mpi base/gcc-mpi
 	touch $@
 
-locks/base-clang-mpi: locks/base-clang-serial
+locks/base-clang-mpi: locks/base-clang-serial base/clang-mpi/Dockerfile
 	$(DOCKER_BUILD) -t $(REPO)/base:clang-mpi base/clang-mpi
 	touch $@
 
@@ -45,6 +45,7 @@ base: $(foreach base, $(DEPS), locks/base-$(call sec,$(base),1,2))
 locks/full-deps-bare:
 	# this is only necessary to ensure compatibility of the Makefile
 	touch $@
+
 locks/full-deps-%: full-deps/%/Dockerfile
 	$(DOCKER_BUILD) -t $(REPO)/full-deps:$* full-deps/$*
 	touch $@

--- a/base/clang-mpi/Dockerfile
+++ b/base/clang-mpi/Dockerfile
@@ -6,12 +6,12 @@ MAINTAINER luca.heltai@gmail.com
 USER root
 
 RUN apt-get update && apt-get -yq install \
-    libopenmpi-dev \
-    openmpi-bin 
+    libmpich-dev \
+    mpich
 
 # Make open mpi use clang
-ENV OMPI_CC clang
-ENV OMPI_CXX clang++
+ENV MPICH_CC clang
+ENV MPICH_CXX clang++
 ENV CC mpicc
 ENV CXX mpicxx
 ENV FC mpif90

--- a/base/clang-mpi/Dockerfile
+++ b/base/clang-mpi/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get -yq install \
     libmpich-dev \
     mpich
 
-# Make open mpi use clang
+# Select default compilers and tell mpi to use clang
 ENV MPICH_CC clang
 ENV MPICH_CXX clang++
 ENV CC mpicc

--- a/base/gcc-mpi/Dockerfile
+++ b/base/gcc-mpi/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER luca.heltai@gmail.com
 USER root
 
 RUN apt-get update && apt-get -yq install \
-    libopenmpi-dev \
-    openmpi-bin \
+    libmpich-dev \
+    mpich \
     python
 
 # Make open mpi the default compiler

--- a/base/gcc-mpi/Dockerfile
+++ b/base/gcc-mpi/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -yq install \
     mpich \
     python
 
-# Make open mpi the default compiler
+# Select the default compiler
 ENV CC mpicc
 ENV CXX mpicxx
 ENV FC mpif90


### PR DESCRIPTION
There are various problems with open MPI:
- when using docker in overlay2 mode, mpirun crashes while parsing
/proc/mounts
- warnings about missing infiniband cards
- problems running with root

So switch to mpich instead.