### PR TITLE
Fix maintainer command

### DIFF
--- a/base/clang-mpi/Dockerfile
+++ b/base/clang-mpi/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/base:clang-serial
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 # based on work by Rene Gassmoeller and Timo Heister
 
 USER root

--- a/base/clang-serial/Dockerfile
+++ b/base/clang-serial/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/ubuntu16
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 # based on work by Rene Gassmoeller and Timo Heister
 
 USER root

--- a/base/gcc-mpi/Dockerfile
+++ b/base/gcc-mpi/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/base:gcc-serial
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 # based on work by Rene Gassmoeller and Timo Heister
 
 USER root

--- a/base/gcc-serial/Dockerfile
+++ b/base/gcc-serial/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/ubuntu16
 
-MAINTAINER timo.heister@gmail.com
+LABEL maintainer="timo.heister@gmail.com"
 
 USER root
 RUN apt-get update && apt-get -yq install \

--- a/dealii/bare/Dockerfile
+++ b/dealii/bare/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/base:clang-serial
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 
 # get deal.II repo
 ARG VER=master

--- a/dealii/fulldepscandi/Dockerfile
+++ b/dealii/fulldepscandi/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/full-deps:fulldepscandi
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 
 # get deal.II repo
 ARG VER=master

--- a/dealii/fulldepsmanual/Dockerfile
+++ b/dealii/fulldepsmanual/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/full-deps:fulldepsmanual
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 
 # get deal.II repo
 ARG VER=master

--- a/dealii/fulldepsspack/Dockerfile
+++ b/dealii/fulldepsspack/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/full-deps:fulldepsspack
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 
 # get deal.II repo
 USER       root

--- a/full-deps/fulldepscandi/Dockerfile
+++ b/full-deps/fulldepscandi/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/base:gcc-mpi
 
-MAINTAINER timo.heister@gmail.com
+LABEL maintainer="timo.heister@gmail.com"
 
 USER root
 RUN apt-get update && apt-get -yq install \

--- a/full-deps/fulldepsmanual/Dockerfile
+++ b/full-deps/fulldepsmanual/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/base:gcc-mpi
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 # based on work by Rene Gassmoeller and Timo Heister
 
 # The base system already contains everything that is needed.

--- a/full-deps/fulldepsspack/Dockerfile
+++ b/full-deps/fulldepsspack/Dockerfile
@@ -1,6 +1,6 @@
 FROM 	   dealii/ubuntu16
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 
 USER 	   root
 

--- a/indent/Dockerfile
+++ b/indent/Dockerfile
@@ -1,6 +1,6 @@
 FROM dealii/base:gcc-serial
 
-MAINTAINER timo.heister@gmail.com
+LABEL maintainer="timo.heister@gmail.com"
 
 USER root
 

--- a/ubuntu16/Dockerfile
+++ b/ubuntu16/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:xenial
 # this is ubuntu 16.04 LTS
 
-MAINTAINER luca.heltai@gmail.com
+LABEL maintainer="luca.heltai@gmail.com"
 
 # Set the locale
 # this is required so that numbers can be formatted with , separators


### PR DESCRIPTION
MAINTAINER command is deprecated within Dockerfile syntax
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
