### PR TITLE
Ver 9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,20 +41,44 @@ v9.2.0-focal:
 	$(DOCKER_BUILD) -t dealii/dealii:v9.2.0-focal \
 		--build-arg VERSION=9.2.0-1~ubuntu20.04.1~ppa1 \
 		--build-arg REPO=ppa:ginggs/deal.ii-9.2.0-backports \
+		--build-arg CLANG_VERSION=6 \
+		--build-arg CLANG_REPO=https://github.com/dealii/dealii/releases/download/v9.0.0/ \
 		focal
 	docker push dealii/dealii:v9.2.0-focal
-	docker tag dealii/dealii:v9.2.0-focal dealii/dealii:latest
+
+v9.3.0-focal:
+	$(DOCKER_BUILD) -t dealii/dealii:v9.3.0-focal \
+		--build-arg VERSION=9.3.0-1~ubuntu20.04.1~ppa1 \
+		--build-arg REPO=ppa:ginggs/deal.ii-9.3.0-backports \
+		--build-arg CLANG_VERSION=11 \
+		--build-arg CLANG_REPO=https://github.com/dealii/dealii/releases/download/v9.3.0/ \
+		focal
+	docker push dealii/dealii:v9.3.0-focal
+	docker tag dealii/dealii:v9.3.0-focal dealii/dealii:latest
 	docker push dealii/dealii:latest
+
+dependencies-focal-v9.2.0:
+	$(DOCKER_BUILD) -t dealii/dependencies:focal-v9.2.0 \
+		--build-arg VERSION=9.2.0-1~ubuntu20.04.1~ppa1 \
+		--build-arg REPO=ppa:ginggs/deal.ii-9.2.0-backports \
+		--build-arg CLANG_VERSION=6 \
+		--build-arg CLANG_REPO=https://github.com/dealii/dealii/releases/download/v9.0.0/ \
+		dependencies-focal
+	docker push dealii/dependencies:focal-v9.2.0
 
 dependencies-focal:
 	$(DOCKER_BUILD) -t dealii/dependencies:focal \
-		--build-arg VERSION=9.2.0-1~ubuntu20.04.1~ppa1 \
-		--build-arg REPO=ppa:ginggs/deal.ii-9.2.0-backports \
+		--build-arg VERSION=9.3.0-1~ubuntu20.04.1~ppa1 \
+		--build-arg REPO=ppa:ginggs/deal.ii-9.3.0-backports \
+		--build-arg CLANG_VERSION=11 \
+		--build-arg CLANG_REPO=https://github.com/dealii/dealii/releases/download/v9.3.0/ \
 		dependencies-focal
 	docker push dealii/dependencies:focal
 	docker tag dealii/dependencies:focal dealii/dependencies:latest
+	docker tag dealii/dependencies:focal dealii/dependencies:focal-v9.3.0
 	docker push dealii/dependencies:latest
+	docker push dealii/dependencies:focal-v9.3.0
 
-all: v9.1.1-bionic v9.2.0-bionic v9.2.0-focal dependencies-focal
+all: v9.3.0-focal dependencies-focal
 
-.PHONY: all v9.1.1-bionic v9.2.0-bionic v9.2.0-focal dependencies-focal
+.PHONY: all v9.1.1-bionic v9.2.0-bionic v9.2.0-focal v9.3.0-focal dependencies-focal-v9.2.0 dependencies-focal

--- a/dependencies-focal/Dockerfile
+++ b/dependencies-focal/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu:focal
 
 LABEL maintainer="luca.heltai@gmail.com"
 
-ARG VERSION=9.2.0-1~ubuntu20.04.1~ppa1
-ARG REPO=ppa:ginggs/deal.ii-9.2.0-backports
+ARG VERSION=9.3.0-1~ubuntu20.04.1~ppa1
+ARG REPO=ppa:ginggs/deal.ii-9.3.0-backports
+ARG CLANG_VERSION=11
+ARG CLANG_REPO=https://github.com/dealii/dealii/releases/download/v9.3.0/
 
 USER root
 RUN apt-get update && apt-get install -y software-properties-common \
@@ -34,8 +36,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8
 
-RUN wget https://github.com/dealii/dealii/releases/download/v9.0.0/clang-format-6-linux.tar.gz \
-    && tar xfv clang* && cp clang-6/bin/clang-format /usr/local/bin/ \
+RUN wget ${CLANG_REPO}/clang-format-${CLANG_VERSION}-linux.tar.gz \
+    && tar xfv clang* && cp clang-${CLANG_VERSION}/bin/clang-format /usr/local/bin/ \
     && rm -rf clang*
 
 # add and enable the default user

--- a/dependencies-focal/Dockerfile
+++ b/dependencies-focal/Dockerfile
@@ -10,18 +10,23 @@ RUN apt-get update && apt-get install -y software-properties-common \
     && add-apt-repository $REPO \
     && apt-get update && apt-get install -y \
     git \
-    googletest \
+    libboost-log1.71-dev \
     libboost-python-dev \
     libdeal.ii-dev=$VERSION \
+    libgtest-dev \
     locales \
     ninja-build \
     numdiff \
     python3-dev \
+    python3-distutils \
+    python3-matplotlib \
     python3-pybind11 \
+    python3-scipy\
     ssh \
     sudo \
     wget \
     && apt-get remove -y libdeal.ii-dev=$VERSION \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN locale-gen en_US.UTF-8  

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu:focal
 
 LABEL maintainer="luca.heltai@gmail.com"
 
-ARG VERSION=9.2.0-1~ubuntu20.04.1~ppa1
-ARG REPO=ppa:ginggs/deal.ii-9.2.0-backports
+ARG VERSION=9.3.0-1~ubuntu20.04.1~ppa1
+ARG REPO=ppa:ginggs/deal.ii-9.3.0-backports
+ARG CLANG_VERSION=11
+ARG CLANG_REPO=https://github.com/dealii/dealii/releases/download/v9.3.0/
 
 USER root
 RUN apt-get update && apt-get install -y software-properties-common \
@@ -12,10 +14,10 @@ RUN apt-get update && apt-get install -y software-properties-common \
     git \
     libdeal.ii-dev=$VERSION \
     locales \
-    ssh \
-    sudo \
     ninja-build \
     numdiff \
+    ssh \
+    sudo \
     wget \
     && rm -rf /var/lib/apt/lists/* \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -24,8 +26,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en  
 ENV LC_ALL en_US.UTF-8
 
-RUN wget https://github.com/dealii/dealii/releases/download/v9.0.0/clang-format-6-linux.tar.gz \
-    && tar xfv clang* && cp clang-6/bin/clang-format /usr/local/bin/ \
+RUN wget ${CLANG_REPO}/clang-format-${CLANG_VERSION}-linux.tar.gz \
+    && tar xfv clang* && cp clang-${CLANG_VERSION}/bin/clang-format /usr/local/bin/ \
     && rm -rf clang*
 
 # add and enable the default user


### PR DESCRIPTION
I realized that, while we do build master versions of the library, we don't have the latest 9.3 dependencies installed when doing so, and we don't have a dealii/dealii:latest pointing to the latest available ubuntu package.