### PR TITLE
Build Arm64 dependencies image

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,63 @@
+name: github-docker
+
+# this workflow only triggers when manually started
+on: workflow_dispatch
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-dependencies:
+    if: (github.repository == 'dealii/docker-files')
+    name: dependencies - ${{ matrix.system.ubuntu_version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+          - ubuntu_version: "focal"
+            dealii_version: 9.4.0-1ubuntu2~bpo20.04.1~ppa1
+            tag: focal-v9.5.1
+          - ubuntu_version: "jammy"
+            dealii_version: 9.4.0-1ubuntu2~bpo22.04.1~ppa1
+            tag: jammy-v9.5.1
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image of dependencies ${{ matrix.system.ubuntu_version }}
+        uses: docker/build-push-action@v5
+        with:
+          context: ./dependencies/
+          cache-from: type=registry,ref=dealii/dependencies:${{ matrix.system.ubuntu_version }}
+          cache-to: type=inline
+          build-args: |
+            IMG=${{ matrix.system.ubuntu_version }}
+            VERSION=${{ matrix.system.dealii_version}}
+          platforms: linux/arm64,linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ matrix.system.tag }}
+            dealii/dependencies:${{ matrix.tag }}

--- a/README.md
+++ b/README.md
@@ -8,20 +8,27 @@ Images are tagged with the ubuntu distribution they are based on.
 
 You can pull any of the images from dockerhub using (for example)
 
-    docker pull dealii/dealii:v9.2.0-focal
+    docker pull dealii/dealii:v9.5.0-jammy
 
 after which you could run an interactive shell in it:
 
-    docker run -i -t dealii/dealii:v9.2.0-focal
+    docker run -i -t dealii/dealii:v9.5.0-jammy
 
 This will drop you in an isolated environment where you can experiment with deal.II.
 
 Versions of interest:
-- ``dealii/dealii:v9.2.0-focal`` - deal.II v9.2.0, Ubuntu 20.04
-- ``dealii/dealii:v9.2.0-bionic`` - deal.II v9.2.0, Ubuntu 18.04
-- ``dealii/dealii:v9.1.1-bionic`` - deal.II v9.1.1, Ubuntu 18.04
+- ``dealii/dealii:v9.5.0-jammy`` - deal.II v9.5.0, Ubuntu 22.04
+- ``dealii/dealii:v9.5.0-focal`` - deal.II v9.5.0, Ubuntu 20.04
+- ``dealii/dealii:v9.4.2-jammy`` - deal.II v9.4.2, Ubuntu 22.04
+- ``dealii/dealii:v9.4.2-focal`` - deal.II v9.4.2, Ubuntu 20.04
 
 A list of all available images is here: 
 
 https://hub.docker.com/r/dealii/dealii/tags/
+
+In addition there are images that only contain the deal.II dependencies, but
+not the library itself. These images are helpful to compile your own version
+of deal.II. All images containing only deal.II dependencies can be found at:
+
+https://hub.docker.com/r/dealii/dependencies/tags/
 


### PR DESCRIPTION
@tjhei @luca-heltai FYI

This PR does:
- update the README.md to recent deal.II versions
- Proposes to add a github actions workflow that:
  - is only manually executed by clicking a button here https://github.com/dealii/docker-files/actions/new
  - builds the dependencies docker image on github actions machines
  - builds both a amd64 and arm64 docker image
  - pushes those docker images both to the github container registry and the docker hub

This change would allow us as a next step to:
- build a deal.II image for both amd64 and arm64
- simplifies rebuilding the images for new deal.II releases

You can see how the final images would look like here: https://github.com/gassmoeller/docker-files/pkgs/container/docker-files (I tested the workflow in my account).

The docker hub upload will not work unless we set up secrets to log into docker hub. If we agree that is a good thing I can do that or someone else can as well. The github container registry upload should word out of the box.

Comments and suggestions are welcome. As discussed with @tjhei I think having a deal.II arm64 image would be worthwhile (because it runs well on the Macs ARM architecture).