### PR TITLE
Add mold to dependencies Dockerfile.

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y software-properties-common \
     libmpc-dev \
     llvm \
     locales \
+    mold \
     ninja-build \
     numdiff \
     python-is-python3 \


### PR DESCRIPTION
Using mold speeds up linking deal.II in the docker images significantly.

Runtime speedups for the github docker workflow: On amd64 from currently 2 hours (jammy) or 3.5 hours (noble) to 1 hour (both).

Further, it makes building arm64 images possible, as without we overshoot the maximum runtime of 6 hours.