### PR TITLE
Remove llvm.

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y software-properties-common \
     libgmp-dev \
     libgtest-dev \
     libmpc-dev \
-    llvm \
     locales \
     mold \
     ninja-build \
@@ -59,7 +58,6 @@ RUN cd /usr/src && \
     -DBUILD_TESTS=off \
     -DINTEGER_CLASS=flint \
     -DWITH_BOOST=on  \
-    -DWITH_LLVM=on \
     -DWITH_MPC=on \
     -DWITH_MPFR=on \
     -DWITH_SYMENGINE_THREAD_SAFE=on \


### PR DESCRIPTION
```
: CommandLine Error: Option 'x86-experimental-lvi-inline-asm-hardening' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
```

We encounter these errors currently on our deal.II github CI.

There are two versions of `libllvm` installed on the dependencies image at the moment, which most likely causes the "... registered more than once!" error. See also: https://stackoverflow.com/questions/65509004/clang-llvm-multiple-version-issue

On the jammy image, those packages are:
```
$ docker run <...> apt search llvm | grep installed
libllvm14/now 1:14.0.0-1ubuntu1.1 amd64 [installed,local]
libllvm15/now 1:15.0.7-0ubuntu0.22.04.3 amd64 [installed,local]
```

`libllvm15` is installed as a dependency of `libdeal.ii-dev` through backports.
`libllvm14` is installed as a dependency of `symengine` in our Dockerfile.

I suggest to remove the (optional) `llvm` dependency of `symengine` to avoid duplicates.