### PR TITLE
Don't install VTK

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -88,31 +88,6 @@ RUN cd /usr/src && \
     cmake -GNinja .. -DCMAKE_INSTALL_PREFIX=/usr/ && \
     ninja install && cd ../ && rm -rf build 
 
-# VTK
-RUN cd /usr/src && \
-    wget https://gitlab.kitware.com/vtk/vtk/-/archive/v9.4.0/vtk-v9.4.0.tar.gz && \
-    tar xvf vtk-v9.4.0.tar.gz && \
-    rm -rf vtk-v9.4.0.tar.gz && \
-    cd vtk-v9.4.0/ && \ 
-    mkdir build && cd build && \
-    cmake -GNinja .. \
-    -DCMAKE_INSTALL_PREFIX=/usr/ \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=ON \
-    -DBUILD_TESTING=OFF \
-    -DVTK_EXTRA_COMPILER_WARNINGS=OFF \
-    -DVTK_GROUP_ENABLE_Imaging=DONT_WANT \
-    -DVTK_GROUP_ENABLE_MPI=DONT_WANT \
-    -DVTK_GROUP_ENABLE_Qt=DONT_WANT \
-    -DVTK_GROUP_ENABLE_Rendering=DONT_WANT \
-    -DVTK_GROUP_ENABLE_StandAlone=WANT \
-    -DVTK_GROUP_ENABLE_Views=DONT_WANT \
-    -DVTK_GROUP_ENABLE_Web=DONT_WANT \
-    -DVTK_USE_MPI=OFF \
-    -DVTK_WRAP_JAVA=OFF \
-    -DVTK_WRAP_PYTHON=OFF && \
-    ninja install && cd ../ && rm -rf build
-
 RUN locale-gen en_US.UTF-8  
 ENV LANG=en_US.UTF-8  
 

--- a/github/Dockerfile
+++ b/github/Dockerfile
@@ -46,7 +46,7 @@ RUN cd /usr/src \
     -DDEAL_II_WITH_TBB=ON \
     -DDEAL_II_WITH_TRILINOS=ON \
     -DDEAL_II_WITH_UMFPACK=ON \
-    -DDEAL_II_WITH_VTK=ON \
+    -DDEAL_II_WITH_VTK=OFF \
     -DDEAL_II_WITH_ZLIB=ON \
     .. \
     && ninja -j $PROCS install \


### PR DESCRIPTION
It seems the workflows time out becuase building VTK takes too long. This pull request proposes to disable the dependency for now.