### PR TITLE
Do not install llvm.

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -21,8 +21,6 @@ RUN apt-get update && apt-get install -y software-properties-common \
     libgmp-dev \
     libgtest-dev \
     libmpc-dev \
-    lld \
-    llvm \
     locales \
     ninja-build \
     numdiff \


### PR DESCRIPTION
Some later PR reverted part of #50.

It is important to _not_ install a second version of llvm to avoid linking problems (with mold)!