### PR TITLE
Build and push dealii docker images via github actions.

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,4 +1,4 @@
-name: github-docker
+name: dependencies
 
 # this workflow only triggers when manually started
 on: workflow_dispatch

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -1,9 +1,7 @@
 name: developer
 
 on:
-  push:
-    branches:
-      - "developer*"
+  workflow_dispatch:
   schedule:
     - cron: "0 */12 * * *"
 
@@ -15,7 +13,7 @@ jobs:
   build-master-docker-ubuntu:
     # Build images for different ubuntu versions on different platforms
 
-    if: (github.event_name == 'schedule' && github.repository == 'dealii/docker-files') || github.event_name != 'schedule'
+    if: github.repository == 'dealii/docker-files'
 
     name: build master docker ${{ matrix.ubuntu_version }} ${{ matrix.architecture }}
     runs-on: ${{ matrix.runs-on }}
@@ -78,7 +76,7 @@ jobs:
   merge:
     # Merge all images for a specific ubuntu version
 
-    if: (github.event_name == 'schedule' && github.repository == 'dealii/docker-files') || github.event_name != 'schedule'
+    if: github.repository == 'dealii/docker-files'
 
     runs-on: ubuntu-24.04
     needs:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -1,0 +1,119 @@
+name: developer
+
+on:
+  push:
+    branches:
+      - "developer*"
+  schedule:
+    - cron: "0 */12 * * *"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-master-docker-ubuntu:
+    # Build images for different ubuntu versions on different platforms
+
+    if: (github.event_name == 'schedule' && github.repository == 'dealii/docker-files') || github.event_name != 'schedule'
+
+    name: build master docker ${{ matrix.ubuntu_version }} ${{ matrix.architecture }}
+    runs-on: ${{ matrix.runs-on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu_version: [jammy, noble]
+        architecture: [amd64, arm64]
+        include:
+          - architecture: amd64
+            runs-on: ubuntu-24.04
+            flags: ""
+          - architecture: arm64
+            runs-on: ubuntu-24.04-arm
+            flags: -mno-outline-atomics
+          # Use all available processors to build.
+          # Specify the number of jobs explicitly since the default '0'
+          # causes the github workers to disconnect (potential crash).
+          - n_jobs: 4
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image of master ${{ matrix.ubuntu_version }}-${{ matrix.architecture }}
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./developer/
+          cache-from: type=registry,ref=dealii/dependencies:${{ matrix.ubuntu_version }}
+          cache-to: type=inline
+          build-args: |
+            IMG=${{ matrix.ubuntu_version }}
+            NJOBS=${{ matrix.n_jobs }}
+            VER=master
+            FLAGS=${{ matrix.flags }}
+          platforms: linux/${{ matrix.architecture }}
+          tags: |
+            ghcr.io/dealii/dealii:master-${{ matrix.ubuntu_version }}-${{ matrix.architecture }}
+            dealii/dealii:master-${{ matrix.ubuntu_version }}-${{ matrix.architecture }}
+          push: true
+
+  merge:
+    # Merge all images for a specific ubuntu version
+
+    if: (github.event_name == 'schedule' && github.repository == 'dealii/docker-files') || github.event_name != 'schedule'
+
+    runs-on: ubuntu-24.04
+    needs:
+      - build-master-docker-ubuntu
+
+    strategy:
+      fail-fast: false
+      matrix:
+        docker:
+          - ghcr.io/dealii/dealii
+          - dealii/dealii
+        ubuntu_version:
+          - jammy
+          - noble
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge images of ${{ matrix.docker }}:${{ matrix.ubuntu_version }}
+        run: |
+          docker buildx imagetools create \
+             -t ${{ matrix.docker }}:master-${{ matrix.ubuntu_version }} \
+             ${{ matrix.docker }}:master-${{ matrix.ubuntu_version }}-amd64 \
+             ${{ matrix.docker }}:master-${{ matrix.ubuntu_version }}-arm64

--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,16 @@ v9.6.2-noble:
 		-t dealii/dealii:latest-${ARCH} \
 		--build-arg IMG=noble \
 		--build-arg VER=v9.6.2 \
-		--build-arg PROCS=12 \
-		github
+		--build-arg NJOBS=12 \
+		developer
 
 v9.6.2-jammy:
 	$(DOCKER_BUILD) \
 		-t dealii/dealii:v9.6.2-jammy-${ARCH} \
 		--build-arg IMG=jammy \
 		--build-arg VER=v9.6.2 \
-		--build-arg PROCS=12 \
-		github
+		--build-arg NJOBS=12 \
+		developer
 
 noble: dependencies-noble v9.6.2-noble 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![workflows/developer](https://github.com/dealii/docker-files/actions/workflows/developer.yml/badge.svg?branch=master)](https://github.com/dealii/docker-files/actions/workflows/developer.yml?query=branch%3Amaster)
+
 # Docker files to create Docker images with deal.II
 
 Started from @tjhei, edited by @luca-heltai

--- a/developer/Dockerfile
+++ b/developer/Dockerfile
@@ -1,22 +1,23 @@
-ARG IMG=jammy
+ARG IMG=noble    # Ubuntu image that contains all corresponding dependencies.
 
 FROM dealii/dependencies:$IMG
 
-LABEL maintainer="luca.heltai@gmail.com"
-
-ARG VER=master
-ARG PROCS=2
+ARG NJOBS=0      # Jobs used for building. Default: Use all available jobs.
+ARG VER=master   # deal.II branch that gets checked out.
+ARG FLAGS=""     # Additional flags for the build.
 
 USER root
-RUN cd /usr/src \
-    && git clone https://github.com/dealii/dealii dealii-$VER \
-    && cd dealii-$VER && git checkout $VER && \
-    mkdir build && cd build \
-    && cmake -GNinja \
+
+RUN cd /usr/src && \
+    git clone https://github.com/dealii/dealii dealii-$VER && \
+    cd dealii-$VER && \
+    git checkout $VER && \
+    mkdir build && cd build && \
+    cmake -GNinja \
     -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/hdf5/openmpi;/usr/include/hdf5/openmpi" \
     -DDEAL_II_ALLOW_AUTODETECTION=OFF \
     -DDEAL_II_COMPONENT_PYTHON_BINDINGS=ON \
-    -DCMAKE_CXX_FLAGS="-std=c++17" \
+    -DCMAKE_CXX_FLAGS="-std=c++20 $FLAGS" \
     -DDEAL_II_WITH_64BIT_INDICES=OFF \
     -DDEAL_II_WITH_ADOLC=ON \
     -DDEAL_II_WITH_ARBORX=OFF \
@@ -25,7 +26,6 @@ RUN cd /usr/src \
     -DDEAL_II_WITH_BOOST=ON \
     -DDEAL_II_WITH_CGAL=ON \
     -DDEAL_II_WITH_COMPLEX_VALUES=ON \
-    -DDEAL_II_WITH_CUDA=OFF \
     -DDEAL_II_WITH_GINKGO=OFF \
     -DDEAL_II_WITH_GMSH=ON \
     -DDEAL_II_WITH_GSL=ON \
@@ -48,9 +48,9 @@ RUN cd /usr/src \
     -DDEAL_II_WITH_UMFPACK=ON \
     -DDEAL_II_WITH_VTK=ON \
     -DDEAL_II_WITH_ZLIB=ON \
-    .. \
-    && ninja -j $PROCS install \
-    && cd ../ && rm -rf .git build
+    .. && \
+    ninja -j $NJOBS install && \
+    cd ../ && rm -rf .git build
 
 USER $USER
 WORKDIR $HOME


### PR DESCRIPTION
__To be merged together with https://github.com/dealii/dealii/pull/18283.__

As discussed on matrix/element, let us migrate the docker infrastructure from [dealii](https://github.com/dealii/dealii) to this repository. With this change, we will have everything related to docker in one spot, including the automated builds via github actions. Changes in the docker infrastructure will no longer have to be coordinated between two repositories. (Essentially addresses what I commented on in https://github.com/dealii/docker-files/pull/45).

This is a list of changes between both repositories to make reviewing easier:

- Changes to Dockerfiles:
  - Renamed folder `docker-files/github` to `docker-files/developer`. The containing Dockerfile represents a build with the current deal.II master branch. I tried to find a more fitting name and decided on _developer_, analogously to our doxygen documentation. I am open for other name suggestions, e.g. _master_.
  - Moved `dealii/contrib/docker/Dockerfile` to `docker-files/developer/Dockerfile`. Files did not change.
- Changes to YML workflow files:
  - Renamed the current `github-docker` workflow file in this repository to `dependencies` to better describe its purpose.
  - Moved `dealii/.github/workflows/docker.yml` to `docker-files/.github/workflows/developer.yml`. Essentially the same files, only the names of the repository and the context folder had to be adjusted.
- Moved the docker badge in `README.md`.
- Removed the `dealii/contrib/CI/make-docker-arm-build.sh` script as it is now obsolete.
- Update `Makefile` due to renaming.