### PR TITLE
Ignore ghcr.

### DIFF
--- a/.github/workflows/dealii.yml
+++ b/.github/workflows/dealii.yml
@@ -60,13 +60,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push Docker image of ${{ matrix.dealii_version }} ${{ matrix.ubuntu_version }}-${{ matrix.architecture }}
         id: build
         uses: docker/build-push-action@v6
@@ -81,7 +74,6 @@ jobs:
             FLAGS=${{ matrix.flags }}
           platforms: linux/${{ matrix.architecture }}
           tags: |
-            ghcr.io/dealii/dealii:${{ matrix.dealii_version }}-${{ matrix.ubuntu_version }}-${{ matrix.architecture }}
             dealii/dealii:${{ matrix.dealii_version }}-${{ matrix.ubuntu_version }}-${{ matrix.architecture }}
           push: true
 
@@ -98,7 +90,6 @@ jobs:
       fail-fast: false
       matrix:
         docker:
-          - ghcr.io/dealii/dealii
           - dealii/dealii
         ubuntu_version:
           - jammy
@@ -116,13 +107,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge images of ${{ matrix.docker }}:${{ matrix.dealii_version }}-${{ matrix.ubuntu_version }}
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,13 +45,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build and push Docker image of dealii/dependencies:${{ matrix.system.ubuntu_version }}-${{ matrix.arch.tag }}
         uses: docker/build-push-action@v6
         with:
@@ -66,7 +59,6 @@ jobs:
           platforms: ${{ matrix.arch.build }}
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ matrix.system.tag }}-${{ matrix.arch.tag }}
             dealii/dependencies:${{ matrix.system.tag }}-${{ matrix.arch.tag }}
 
   merge-dependencies:
@@ -79,7 +71,6 @@ jobs:
       fail-fast: false
       matrix:
         docker:
-          - ghcr.io/${{ github.repository }}
           - dealii/dependencies
         os:
           - jammy
@@ -96,13 +87,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge images of ${{ matrix.docker }}:${{ matrix.os }}
         run: |


### PR DESCRIPTION
We currently can't push from `docker-files` to the main repository `dealii` on ghcr.
```
ERROR: failed to solve: failed to push ghcr.io/dealii/dealii:master-jammy-amd64: unexpected status from HEAD request to https://ghcr.io/v2/dealii/dealii/blobs/sha256:9cb31e2e37eab1bff50f727e979fcacb509e225fb853433a6fe21d2fb34e6305: 403 Forbidden
```

This PR is a pragmatic solution and skips pushing to ghcr altogether.

If we decide to use ghcr at some point, we can enable it again.