### PR TITLE
No longer build jammy image.

### DIFF
--- a/.github/workflows/dealii.yml
+++ b/.github/workflows/dealii.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu_version: [jammy, noble]
+        ubuntu_version: [noble]
         architecture: [amd64, arm64]
         include:
           - architecture: amd64
@@ -91,7 +91,6 @@ jobs:
         docker:
           - dealii/dealii
         ubuntu_version:
-          - jammy
           - noble
         include:
           # Specify default version for 'schedule' event

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -25,9 +25,6 @@ jobs:
             tag: amd64
 
         system:
-          - ubuntu_version: jammy
-            dealii_version: 9.7.1-1~ubuntu22.04.1~ppa1
-            tag: jammy-v9.7.1
           - ubuntu_version: noble
             dealii_version: 9.7.1-1~ubuntu24.04.1~ppa1
             tag: noble-v9.7.1
@@ -72,7 +69,6 @@ jobs:
         docker:
           - dealii/dependencies
         os:
-          - jammy
           - noble
         ver:
           - v9.7.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------
 #
-# Copyright (C) 2020 - 2025 by the deal.II authors
+# Copyright (C) 2020 - 2026 by the deal.II authors
 #
 # This file is part of the deal.II library.
 #
@@ -22,15 +22,6 @@ ARCH=amd64
 endif
 
 DOCKER_BUILD=docker buildx build --push --platform $(PLATFORM) --output type=registry
-
-dependencies-jammy:
-	$(DOCKER_BUILD) \
-		-t dealii/dependencies:jammy-${ARCH} \
-		-t dealii/dependencies:jammy-v9.7.1-${ARCH} \
-		--build-arg IMG=jammy \
-                --build-arg VERSION=9.7.1-1~ubuntu22.04.1~ppa1 \
-                --build-arg REPO=ppa:ginggs/deal.ii-9.7.1-backports \
-                ./dependencies
 
 dependencies-noble:
 	$(DOCKER_BUILD) \
@@ -61,24 +52,12 @@ v9.7.1-noble:
 		--build-arg NJOBS=12 \
 		./dealii
 
-v9.7.1-jammy:
-	$(DOCKER_BUILD) \
-		-t dealii/dealii:v9.7.1-jammy-${ARCH} \
-		--build-arg IMG=jammy \
-		--build-arg VER=v9.7.1 \
-		--build-arg NJOBS=12 \
-		./dealii
-
 noble: dependencies-noble v9.7.1-noble
 
-jammy: dependencies-jammy v9.7.1-jammy
-
-all: noble jammy
+all: noble
 
 .PHONY: all \
-	dependencies-jammy \
 	dependencies-noble \
 	dependencies-%-merge \
 	%-merge \
-	v9.7.1-jammy \
 	v9.7.1-noble

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -47,22 +47,20 @@ RUN wget https://raw.githubusercontent.com/dealii/dealii/refs/heads/master/contr
     && mv programs/clang-16/bin/clang-format /usr/local/bin/ \
     && rm -rf download_clang_format programs
 
-ARG IMG
-# ArborX jammy's Kokkos version is too old for the minimum ArborX version
-RUN if [ "$IMG" != "jammy" ]; then \
-      cd /usr/src && \
-      wget https://github.com/arborx/ArborX/archive/refs/tags/v2.1.tar.gz && \
-      tar xvf v2.1.tar.gz && \
-      rm -rf v2.1.tar.gz && \
-      cd ArborX-2.1/ && \
-      mkdir build && cd build && \
-      cmake -GNinja .. \
-      -DCMAKE_INSTALL_PREFIX=/usr/ \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=ON \
-      -DARBORX_ENABLE_MPI=ON && \
-      ninja install && cd ../ && rm -rf build; \
-    fi
+# ArborX
+RUN cd /usr/src && \
+    wget https://github.com/arborx/ArborX/archive/refs/tags/v2.1.tar.gz && \
+    tar xvf v2.1.tar.gz && \
+    rm -rf v2.1.tar.gz && \
+    cd ArborX-2.1/ && \
+    mkdir build && cd build && \
+    cmake -GNinja .. \
+    -DCMAKE_INSTALL_PREFIX=/usr/ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=ON \
+    -DARBORX_ENABLE_MPI=ON && \
+    ninja install && \
+    cd .. && rm -rf build
 
 # mold
 # We require at least mold 2.32 to be able to link deal.II on ARM architectures.


### PR DESCRIPTION
Only the `noble` dependencies image contains the ArborX dependency. This way, we would also need to build to different deal.II images, which diverge in terms of dependencies and might lead to confusion of our users.

Thus to keep things simple, I suggest to skip building the `jammy` version of our master image altogether. LTS will be over anyways when our next deal.II release happens, and `resolute` should be our next target.

See also #77, #78, #79, #81.