### PR TITLE
Build dependencies image on resolute/26.04 without backports.

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -31,10 +31,16 @@ jobs:
         system:
           - ubuntu_version: jammy
             dealii_version: 9.7.1-1~ubuntu22.04.1~ppa1
+            repository: ppa:ginggs/deal.ii-9.7.1-backports
             tag: jammy-v9.7.1
           - ubuntu_version: noble
             dealii_version: 9.7.1-1~ubuntu24.04.1~ppa1
+            repository: ppa:ginggs/deal.ii-9.7.1-backports
             tag: noble-v9.7.1
+          - ubuntu_version: resolute
+            dealii_version: 9.7.1-5
+            repository:
+            tag: resolute-v9.7.1
 
     steps:
       - name: Checkout code
@@ -58,8 +64,8 @@ jobs:
           cache-to: type=inline
           build-args: |
             IMG=${{ matrix.system.ubuntu_version }}
-            VERSION=${{ matrix.system.dealii_version}}
-            REPO=ppa:ginggs/deal.ii-9.7.1-backports
+            VERSION=${{ matrix.system.dealii_version }}
+            REPO=${{ matrix.system.repository }}
           platforms: ${{ matrix.arch.build }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
@@ -82,6 +88,7 @@ jobs:
         os:
           - jammy
           - noble
+          - resolute
         ver:
           - v9.7.1
 

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -8,10 +8,13 @@ ARG REPO=ppa:ginggs/deal.ii-9.7.1-backports
 USER root
 ENV DEBIAN_FRONTEND=noninteractive 
 
-RUN apt-get update && apt-get install -y software-properties-common \
-    && add-apt-repository $REPO \
-    && apt-get update && \
-    apt-get install -y \
+RUN apt-get update \
+    && if [ -n "$REPO" ]; then \
+      apt-get install -y software-properties-common \
+      && add-apt-repository $REPO \
+      && apt-get update; \
+    fi \
+    && apt-get install -y \
     git \
     libboost-dev \
     libboost-python-dev \
@@ -35,11 +38,7 @@ RUN apt-get update && apt-get install -y software-properties-common \
     wget \
     && apt-get remove -y libdeal.ii-dev=$VERSION libcgal-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-
-ENV LANGUAGE=en_US:en  
-ENV LC_ALL=en_US.UTF-8
+    && rm -rf /var/lib/apt/lists/*
 
 RUN wget https://raw.githubusercontent.com/dealii/dealii/refs/heads/master/contrib/utilities/download_clang_format \
     && chmod +x download_clang_format \
@@ -144,8 +143,10 @@ RUN cd /usr/src && \
     -DVTK_WRAP_PYTHON=OFF && \
     ninja install && cd ../ && rm -rf build
 
-RUN locale-gen en_US.UTF-8  
-ENV LANG=en_US.UTF-8  
+RUN locale-gen en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 RUN ldconfig
 ENV PYTHONPATH="/usr/local/lib/python3.8/site-packages/"


### PR DESCRIPTION
Prequel to #77. @masterleinad -- What do you think?

This patch allows to build the dependencies image without specifying a backports repository. It allows us to build an image for resolute/26.04 based on the vanilla ubuntu repositories. We can use this image to run the main repository CI on the resolute/26.04 platform in preparation of the deal.II 9.8 release. We will update the dependencies image to use backports once necessary/available.

I successfully built the resolute dependencies image on my forked repository. I did not check whether I can successfully build deal.II with it yet. Will do in a separate PR. This reminds me of #59.

---

I had to remove the `localedef` command as it failed in the resolute/26.04 constellation with
```
locale alias file `/usr/share/locale/locale.alias' not found: No such file or directory
```
This command was introduced in 32540c9a8192f811a52ba5043b706e1a461cbf9e. I do not know if we still need it. @luca-heltai , @tjhei -- Do you recall?

I grouped all other lines related to `locale` settings.

