### PR TITLE
Patch symengine to be compatible with cmake >=4.0.

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -80,10 +80,15 @@ RUN cd /usr/src && \
     cd .. && rm -rf build
 
 # Symengine
+# We need to patch the CMake version requirement to be able to call find_package(SymEngine)
+# with CMake >=4.0 as compatibility with CMake <3.5 has been removed.
+# This patch will no longer be necessary for Symengine >=0.15.0.
 RUN cd /usr/src && \
     wget https://github.com/symengine/symengine/releases/download/v0.14.0/symengine-0.14.0.tar.gz && \
     tar xvfz symengine-0.14.0.tar.gz && rm symengine-0.14.0.tar.gz &&\
-    cd symengine-0.14.0 && mkdir build && cd build && \
+    cd symengine-0.14.0 && \
+    sed -i -e "s/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.13)/" cmake/SymEngineConfig.cmake.in && \
+    mkdir build && cd build && \
     cmake \
     -DBUILD_BENCHMARKS=off \
     -DBUILD_SHARED_LIBS=on \


### PR DESCRIPTION
Follow-up to #85.

The resolute/26.04 images come with CMake 4.2.3 which has removed compatibility with CMake < 3.5.

We can configure symengine as their top-level `CMakeLists.txt` requires CMake >= 3.13, and we are able to compile and install it. However, their `SymEngineConfig.cmake` file still requires CMake >= 2.8.12 which is no longer supported, and `find_package(SymEngine)` will fail. This patch aligns their `cmake_minimum_required` to their top-level `CMakeLists.txt`.

This has been fixed in their master branch, so the proposed patch in this PR will no longer be necessary starting their next 0.15.0 release (in preparation).