### PR TITLE
Patch symengine to use <version> instead of <ciso646>.

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -82,12 +82,15 @@ RUN cd /usr/src && \
 # Symengine
 # We need to patch the CMake version requirement to be able to call find_package(SymEngine)
 # with CMake >=4.0 as compatibility with CMake <3.5 has been removed.
-# This patch will no longer be necessary for Symengine >=0.15.0.
+# We also need to patch the inclusion of <ciso646> which has been replaced with <version>
+# in C++20.
+# Both patches will no longer be necessary for Symengine >=0.15.0.
 RUN cd /usr/src && \
     wget https://github.com/symengine/symengine/releases/download/v0.14.0/symengine-0.14.0.tar.gz && \
     tar xvfz symengine-0.14.0.tar.gz && rm symengine-0.14.0.tar.gz &&\
     cd symengine-0.14.0 && \
     sed -i -e "s/cmake_minimum_required(VERSION 2.8.12)/cmake_minimum_required(VERSION 3.13)/" cmake/SymEngineConfig.cmake.in && \
+    sed -i -e "s/#include <ciso646>/#if __cplusplus <= 201703L\n#include <ciso646>\n#else\n#include <version>\n#endif/" symengine/prime_sieve.cpp symengine/symengine_rcp.h && \
     mkdir build && cd build && \
     cmake \
     -DBUILD_BENCHMARKS=off \


### PR DESCRIPTION
Follow-up to #87, #85.

In https://github.com/dealii/dealii/pull/20085, gcc 15.2.0 reports a warning with symengine and C++20 (which we treat as an error).
```
In file included from /usr/local/include/symengine/symengine_rcp.h:8,
                 from /usr/local/include/symengine/mp_wrapper.h:4,
                 from /usr/local/include/symengine/mp_class.h:8,
                 from /usr/local/include/symengine/dict.h:9,
                 from /usr/local/include/symengine/basic.h:37,
                 from /__w/dealii/dealii/include/deal.II/differentiation/sd/symengine_number_types.h:21,
                 from /__w/dealii/dealii/include/deal.II/differentiation/sd/symengine_math.h:20,
                 from /__w/dealii/dealii/include/deal.II/differentiation/sd.h:20,
                 from /__w/dealii/dealii/include/deal.II/base/symbolic_function.h:25,
                 from /__w/dealii/dealii/include/deal.II/base/symbolic_function.templates.h:18,
                 from /__w/dealii/dealii/source/base/symbolic_function.cc:13:
/usr/include/c++/15/ciso646:49:6: error: #warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros" [-Werror=cpp]
   49 | #    warning "<ciso646> is not a standard header since C++20, use <version> to detect implementation-specific macros"
      |      ^~~~~~~
cc1plus: all warnings being treated as errors
```

This PR applies https://github.com/symengine/symengine/pull/2102 to our build process for symengine 0.14.0 via `sed`.

This has been fixed in their master branch, so the proposed patch in this PR will no longer be necessary starting their next 0.15.0 release (in preparation).